### PR TITLE
Support for context on server and clients, do not panic, unary middleware on server and clients

### DIFF
--- a/go/impl/call_options.go
+++ b/go/impl/call_options.go
@@ -3,6 +3,9 @@ package impl
 import (
 	"context"
 	"time"
+
+	"github.com/nats-io/nats.go"
+
 	"xiam.li/protonats/go/protonats"
 )
 
@@ -14,6 +17,17 @@ type CallOpts struct {
 	Context         context.Context
 	DisableFinisher bool
 	ExtraSubject    string
+	Headers         nats.Header
+}
+
+func (opts *CallOpts) WithHeader(header, value string) {
+	if opts.Headers == nil {
+		opts.Headers = make(nats.Header)
+	}
+	if opts.Headers[header] == nil {
+		opts.Headers[header] = make([]string, 0)
+	}
+	opts.Headers[header] = append(opts.Headers[header], value)
 }
 
 func (opts *CallOpts) WithoutFinisher() {

--- a/go/impl/client_options.go
+++ b/go/impl/client_options.go
@@ -1,0 +1,35 @@
+package impl
+
+import (
+	"context"
+
+	"xiam.li/protonats/go/protonats"
+)
+
+type ClientOpts struct {
+	ClientContext        context.Context
+	UnaryMiddlewareChain []protonats.ClientUnaryMiddleware
+}
+
+func ProcessClientOptions(opts ...protonats.ClientOption) *ClientOpts {
+	options := new(ClientOpts)
+
+	// Set defaults
+	options.ClientContext = context.Background()
+
+	for _, opt := range opts {
+		opt(options)
+	}
+	return options
+}
+
+func (opts *ClientOpts) SetClientContext(ctx context.Context) {
+	opts.ClientContext = ctx
+}
+
+func (opts *ClientOpts) SetUnaryMiddlewareChain(unaryMiddlewares ...protonats.ClientUnaryMiddleware) {
+	opts.UnaryMiddlewareChain = unaryMiddlewares
+}
+
+// Interface guard
+var _ protonats.ClientOptions = (*ClientOpts)(nil)

--- a/go/impl/client_options_test.go
+++ b/go/impl/client_options_test.go
@@ -1,0 +1,52 @@
+package impl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nats-io/nats.go"
+
+	"xiam.li/protonats/go/protonats"
+)
+
+func TestClientOpts_WithClientContext(t *testing.T) {
+	opts := new(ClientOpts)
+	protonats.WithClientContext(context.TODO())(opts)
+	if opts.ClientContext != context.TODO() {
+		t.Error("ClientContext not set correctly")
+	}
+}
+
+func TestClientOpts_WithClientUnaryInterceptorChain(t *testing.T) {
+	opts := new(ClientOpts)
+	dummyClientUnaryInterceptor := func(next protonats.ClientUnaryMiddlewareHandler) protonats.ClientUnaryMiddlewareHandler {
+		return func(ctx context.Context, request *nats.Msg) (*nats.Msg, error) {
+			return next(ctx, request)
+		}
+	}
+	protonats.WithClientUnaryInterceptorChain(dummyClientUnaryInterceptor)(opts)
+	if opts.UnaryMiddlewareChain == nil {
+		t.Error("UnaryMiddlewareChain not set correctly")
+	}
+}
+
+func TestProcessClientOptions(t *testing.T) {
+	t.Run("WithMicroConfig", func(t *testing.T) {
+		dummyClientUnaryInterceptor := func(next protonats.ClientUnaryMiddlewareHandler) protonats.ClientUnaryMiddlewareHandler {
+			return func(ctx context.Context, request *nats.Msg) (*nats.Msg, error) {
+				return next(ctx, request)
+			}
+		}
+
+		opts := ProcessClientOptions(
+			protonats.WithClientContext(context.TODO()),
+			protonats.WithClientUnaryInterceptorChain(dummyClientUnaryInterceptor),
+		)
+		if opts.ClientContext != context.TODO() {
+			t.Error("ClientContext not set correctly")
+		}
+		if opts.UnaryMiddlewareChain == nil {
+			t.Error("UnaryMiddlewareChain not set correctly")
+		}
+	})
+}

--- a/go/impl/server_options.go
+++ b/go/impl/server_options.go
@@ -1,8 +1,11 @@
 package impl
 
 import (
-	"github.com/nats-io/nats.go/micro"
+	"context"
 	"time"
+
+	"github.com/nats-io/nats.go/micro"
+
 	"xiam.li/protonats/go/protonats"
 )
 
@@ -16,10 +19,16 @@ type ServerOpts struct {
 	StatsHandler             *micro.StatsHandler
 	DoneHandler              *micro.DoneHandler
 	ErrorHandler             *micro.ErrHandler
+	ServerContext            context.Context
+	UnaryInterceptorsChain   []protonats.UnaryMiddleware
 }
 
 func ProcessServerOptions(config *micro.Config, opts ...protonats.ServerOption) *ServerOpts {
 	options := new(ServerOpts)
+
+	// Set defaults
+	options.ServerContext = context.Background()
+
 	for _, opt := range opts {
 		opt(options)
 	}
@@ -60,6 +69,14 @@ func (opts *ServerOpts) WithoutLeaderFns() {
 
 func (opts *ServerOpts) WithoutFollowerFns() {
 	opts.WithoutFollowerFunctions = true
+}
+
+func (opts *ServerOpts) SetServerContext(ctx context.Context) {
+	opts.ServerContext = ctx
+}
+
+func (opts *ServerOpts) SetUnaryInterceptorsChain(unaryInterceptors ...protonats.UnaryMiddleware) {
+	opts.UnaryInterceptorsChain = unaryInterceptors
 }
 
 func (opts *ServerOpts) SetExtraSubject(extraSubject string) {

--- a/go/impl/server_options.go
+++ b/go/impl/server_options.go
@@ -20,7 +20,7 @@ type ServerOpts struct {
 	DoneHandler              *micro.DoneHandler
 	ErrorHandler             *micro.ErrHandler
 	ServerContext            context.Context
-	UnaryInterceptorsChain   []protonats.UnaryMiddleware
+	UnaryMiddlewareChain     []protonats.ServerUnaryMiddleware
 }
 
 func ProcessServerOptions(config *micro.Config, opts ...protonats.ServerOption) *ServerOpts {
@@ -75,8 +75,8 @@ func (opts *ServerOpts) SetServerContext(ctx context.Context) {
 	opts.ServerContext = ctx
 }
 
-func (opts *ServerOpts) SetUnaryInterceptorsChain(unaryInterceptors ...protonats.UnaryMiddleware) {
-	opts.UnaryInterceptorsChain = unaryInterceptors
+func (opts *ServerOpts) SetUnaryMiddlewareChain(unaryMiddlewares ...protonats.ServerUnaryMiddleware) {
+	opts.UnaryMiddlewareChain = unaryMiddlewares
 }
 
 func (opts *ServerOpts) SetExtraSubject(extraSubject string) {
@@ -99,3 +99,11 @@ func _subject(subject, extra, suffix string) string {
 
 // Interface guard
 var _ protonats.ServerOptions = (*ServerOpts)(nil)
+
+func ApplyServerUnaryMiddlewares(handler protonats.ServerUnaryMiddlewareHandler,
+	middlewares ...protonats.ServerUnaryMiddleware) protonats.ServerUnaryMiddlewareHandler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+	return handler
+}

--- a/go/impl/service.go
+++ b/go/impl/service.go
@@ -1,13 +1,16 @@
 package impl
 
 import (
+	"log/slog"
+
 	"github.com/nats-io/nats.go"
 	"github.com/nats-io/nats.go/micro"
-	"log/slog"
+
 	"xiam.li/protonats/go/protonats"
 )
 
-func NewService(name string, conn *nats.Conn, impl any, opts ...protonats.ServerOption) (micro.Service, *ServerOpts, error) {
+func NewService(name string, conn *nats.Conn, impl any, opts ...protonats.ServerOption) (micro.Service, *ServerOpts,
+	error) {
 	config := micro.Config{
 		Name:    name,
 		Version: "1.0.0",
@@ -38,4 +41,12 @@ func NewService(name string, conn *nats.Conn, impl any, opts ...protonats.Server
 	}
 
 	return service, options, nil
+}
+
+func ApplyMiddlewares(handler protonats.UnaryMiddlewareHandler,
+	middlewares ...protonats.UnaryMiddleware) protonats.UnaryMiddlewareHandler {
+	for i := len(middlewares) - 1; i >= 0; i-- {
+		handler = middlewares[i](handler)
+	}
+	return handler
 }

--- a/go/impl/service.go
+++ b/go/impl/service.go
@@ -42,11 +42,3 @@ func NewService(name string, conn *nats.Conn, impl any, opts ...protonats.Server
 
 	return service, options, nil
 }
-
-func ApplyMiddlewares(handler protonats.UnaryMiddlewareHandler,
-	middlewares ...protonats.UnaryMiddleware) protonats.UnaryMiddlewareHandler {
-	for i := len(middlewares) - 1; i >= 0; i-- {
-		handler = middlewares[i](handler)
-	}
-	return handler
-}

--- a/go/protonats/call_options.go
+++ b/go/protonats/call_options.go
@@ -13,6 +13,7 @@ type CallOptions interface {
 	WithoutFinisher()
 	SetExtraSubject(subject string)
 	SetContext(ctx context.Context)
+	WithHeader(header, value string)
 }
 
 type CallOption func(options CallOptions)
@@ -61,5 +62,12 @@ func WithExtraSubject(extraSubject string) CallOption {
 func WithContext(ctx context.Context) CallOption {
 	return func(options CallOptions) {
 		options.SetContext(ctx)
+	}
+}
+
+// WithHeader sets the header for the call.
+func WithHeader(header, value string) CallOption {
+	return func(options CallOptions) {
+		options.WithHeader(header, value)
 	}
 }

--- a/go/protonats/client_options.go
+++ b/go/protonats/client_options.go
@@ -1,0 +1,37 @@
+package protonats
+
+import (
+	"context"
+
+	"github.com/nats-io/nats.go"
+)
+
+// ClientOptions to be used when creating a new client.
+type ClientOptions interface {
+	SetClientContext(ctx context.Context)
+	SetUnaryMiddlewareChain(unaryMiddlewares ...ClientUnaryMiddleware)
+}
+
+type ClientOption func(options ClientOptions)
+
+// ClientUnaryMiddlewareHandler ClientUnaryMiddleware handler function
+type ClientUnaryMiddlewareHandler func(ctx context.Context, request *nats.Msg) (*nats.Msg, error)
+
+// ClientUnaryMiddleware used to intercept requests before they are processed by client handler function
+type ClientUnaryMiddleware func(next ClientUnaryMiddlewareHandler) ClientUnaryMiddlewareHandler
+
+// WithClientContext sets client base context.
+// Used as a base context for all interceptors and requests.
+func WithClientContext(ctx context.Context) ClientOption {
+	return func(options ClientOptions) {
+		options.SetClientContext(ctx)
+	}
+}
+
+// WithClientUnaryInterceptorChain sets a chain of unary interceptors.
+// Used to process request before passed to server implementation.
+func WithClientUnaryInterceptorChain(unaryMiddlewares ...ClientUnaryMiddleware) ClientOption {
+	return func(options ClientOptions) {
+		options.SetUnaryMiddlewareChain(unaryMiddlewares...)
+	}
+}

--- a/go/protonats/server_options.go
+++ b/go/protonats/server_options.go
@@ -7,11 +7,11 @@ import (
 	"github.com/nats-io/nats.go/micro"
 )
 
-// UnaryMiddlewareHandler UnaryMiddleware handler function
-type UnaryMiddlewareHandler func(ctx context.Context, request micro.Request)
+// ServerUnaryMiddlewareHandler ServerUnaryMiddleware handler function
+type ServerUnaryMiddlewareHandler func(ctx context.Context, request micro.Request)
 
-// UnaryMiddleware used to intercept requests before they are processed by server handler function
-type UnaryMiddleware func(next UnaryMiddlewareHandler) UnaryMiddlewareHandler
+// ServerUnaryMiddleware used to intercept requests before they are processed by server handler function
+type ServerUnaryMiddleware func(next ServerUnaryMiddlewareHandler) ServerUnaryMiddlewareHandler
 
 // Those handler interfaces can be implemented by the respective NATS server impl,
 //as an alternative to setting a handler via an option when creating the server.
@@ -50,7 +50,7 @@ type ServerOptions interface {
 	WithoutFollowerFns()
 	SetExtraSubject(string)
 	SetServerContext(ctx context.Context)
-	SetUnaryInterceptorsChain(unaryInterceptors ...UnaryMiddleware)
+	SetUnaryMiddlewareChain(unaryInterceptors ...ServerUnaryMiddleware)
 }
 
 type ServerOption func(options ServerOptions)
@@ -119,10 +119,10 @@ func WithServerContext(ctx context.Context) ServerOption {
 	}
 }
 
-// WithUnaryInterceptorChain sets a chain of unary interceptors.
+// WithServerUnaryInterceptorChain sets a chain of unary interceptors.
 // Used to process request before passed to server implementation.
-func WithUnaryInterceptorChain(unaryInterceptorsChain ...UnaryMiddleware) ServerOption {
+func WithServerUnaryInterceptorChain(unaryInterceptorsChain ...ServerUnaryMiddleware) ServerOption {
 	return func(options ServerOptions) {
-		options.SetUnaryInterceptorsChain(unaryInterceptorsChain...)
+		options.SetUnaryMiddlewareChain(unaryInterceptorsChain...)
 	}
 }

--- a/go/protonats/server_options.go
+++ b/go/protonats/server_options.go
@@ -1,9 +1,17 @@
 package protonats
 
 import (
-	"github.com/nats-io/nats.go/micro"
+	"context"
 	"time"
+
+	"github.com/nats-io/nats.go/micro"
 )
+
+// UnaryMiddlewareHandler UnaryMiddleware handler function
+type UnaryMiddlewareHandler func(ctx context.Context, request micro.Request)
+
+// UnaryMiddleware used to intercept requests before they are processed by server handler function
+type UnaryMiddleware func(next UnaryMiddlewareHandler) UnaryMiddlewareHandler
 
 // Those handler interfaces can be implemented by the respective NATS server impl,
 //as an alternative to setting a handler via an option when creating the server.
@@ -41,6 +49,8 @@ type ServerOptions interface {
 	WithoutLeaderFns()
 	WithoutFollowerFns()
 	SetExtraSubject(string)
+	SetServerContext(ctx context.Context)
+	SetUnaryInterceptorsChain(unaryInterceptors ...UnaryMiddleware)
 }
 
 type ServerOption func(options ServerOptions)
@@ -98,5 +108,21 @@ func WithoutFollowerFns() ServerOption {
 func WithExtraSubjectSrv(extraSubject string) ServerOption {
 	return func(options ServerOptions) {
 		options.SetExtraSubject(extraSubject)
+	}
+}
+
+// WithServerContext sets server context.
+// Used as a base context for all interceptors and requests.
+func WithServerContext(ctx context.Context) ServerOption {
+	return func(options ServerOptions) {
+		options.SetServerContext(ctx)
+	}
+}
+
+// WithUnaryInterceptorChain sets a chain of unary interceptors.
+// Used to process request before passed to server implementation.
+func WithUnaryInterceptorChain(unaryInterceptorsChain ...UnaryMiddleware) ServerOption {
+	return func(options ServerOptions) {
+		options.SetUnaryInterceptorsChain(unaryInterceptorsChain...)
 	}
 }


### PR DESCRIPTION
Goal of this change to allow intercept requests both on server and client sides. This allows to modify request objects before sending it by client or process by server. For example, to pass authentication headers or create security context.

@d0x7 I've refactored some code.
Could you please check this?